### PR TITLE
[Crawleyprint] Moves coffee-script to dependences instead devDependences

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,7 @@
     "passport-local": "1.0.0",
     "gzippo": "0.2.0",
     "is-running": "1.0.5",
-    "source-map-support": "0.2.7"
-  },
-  "devDependencies": {
+    "source-map-support": "0.2.7",
     "coffee-script": "1.7.1"
   },
   "engines": {


### PR DESCRIPTION
Turns out coffee-script is needed at runtime and tapchat
won't start until CS has been installed manually. This should
get rid of that.
